### PR TITLE
Bump .NET version of Example and Tests to .NET Core 6

### DIFF
--- a/PortaCapena.OdooJsonRpcClient.Example/PortaCapena.OdooJsonRpcClient.Example.csproj
+++ b/PortaCapena.OdooJsonRpcClient.Example/PortaCapena.OdooJsonRpcClient.Example.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/PortaCapena.OdooJsonRpcClient.Tests/PortaCapena.OdooJsonRpcClient.Tests.csproj
+++ b/PortaCapena.OdooJsonRpcClient.Tests/PortaCapena.OdooJsonRpcClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
This is for the Sample and Tests projects only.
Since those project are not published, it would be great to use more recent (and supported) version of the .NET.
.NET Core 6 is installed by default on Ubuntu and supported on Mac and Windows.