### PR TITLE
Generate partial .NET classes in GetDotNetModel

### DIFF
--- a/PortaCapena.OdooJsonRpcClient/Converters/OdooModelMapper.cs
+++ b/PortaCapena.OdooJsonRpcClient/Converters/OdooModelMapper.cs
@@ -100,7 +100,7 @@ namespace PortaCapena.OdooJsonRpcClient.Converters
             var builder = new StringBuilder();
             builder.AppendLine($"[OdooTableName(\"{tableName}\")]");
             builder.AppendLine($"[JsonConverter(typeof({nameof(OdooModelConverter)}))]");
-            builder.AppendLine($"public class {ConvertOdooNameToDotNet(tableName)}{OdooModelSuffix} : IOdooModel");
+            builder.AppendLine($"public partial class {ConvertOdooNameToDotNet(tableName)}{OdooModelSuffix} : IOdooModel");
             builder.AppendLine("{");
 
             foreach (var property in properties)


### PR DESCRIPTION
By making the .NET models partial, developers can add fields, code or interface implementations or even base class. This allow a more flexible work flow where the developer generate only the model he needs. Then customize some of them (on separate files).
Later they can generate again additional models without conflicting with their customizations.