### PR TITLE
Handle json field type

### DIFF
--- a/PortaCapena.OdooJsonRpcClient/Models/OdooPropertyInfo.cs
+++ b/PortaCapena.OdooJsonRpcClient/Models/OdooPropertyInfo.cs
@@ -89,6 +89,7 @@ namespace PortaCapena.OdooJsonRpcClient.Models
                 case "boolean":
                     return OdooValueTypeEnum.Boolean;
                 case "char":
+                case "json":
                     return OdooValueTypeEnum.Char;
                 case "date":
                     return OdooValueTypeEnum.Date;


### PR DESCRIPTION
In v16 some field have a type `json` in the `account.move.line` for example. 

I suggest to map them to a simple string property. Developers can do whatever they want with it.
They can use a Json serializer to map them to a strongly typed struct if they want or leave it as is if they only want to read and write the info (for data migration).