### PR TITLE
Add a Timeout option on OdooClient

### DIFF
--- a/PortaCapena.OdooJsonRpcClient/Models/OdooConfig.cs
+++ b/PortaCapena.OdooJsonRpcClient/Models/OdooConfig.cs
@@ -24,17 +24,17 @@ namespace PortaCapena.OdooJsonRpcClient.Models
             this.Timeout = timeout;
         }
 
-        public OdooConfig(string apiUrl, string dbName, string userName, string password, OdooContext context) : this(apiUrl, dbName, userName, password)
+        public OdooConfig(string apiUrl, string dbName, string userName, string password, OdooContext context, TimeSpan timeout = default(TimeSpan)) : this(apiUrl, dbName, userName, password, timeout)
         {
             this.Context = new OdooContext(context);
         }
 
-        public OdooConfig(string apiUrl, string dbName, string userName, string password, string language) : this(apiUrl, dbName, userName, password)
+        public OdooConfig(string apiUrl, string dbName, string userName, string password, string language, TimeSpan timeout = default(TimeSpan)) : this(apiUrl, dbName, userName, password, timeout)
         {
             this.Context = new OdooContext(language);
         }
 
-        public OdooConfig(string apiUrl, string dbName, string userName, string password, string language, string timezone) : this(apiUrl, dbName, userName, password)
+        public OdooConfig(string apiUrl, string dbName, string userName, string password, string language, string timezone, TimeSpan timeout = default(TimeSpan)) : this(apiUrl, dbName, userName, password, timeout)
         {
             this.Context = new OdooContext(language, timezone);
         }

--- a/PortaCapena.OdooJsonRpcClient/Models/OdooConfig.cs
+++ b/PortaCapena.OdooJsonRpcClient/Models/OdooConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace PortaCapena.OdooJsonRpcClient.Models
+﻿using System;
+
+namespace PortaCapena.OdooJsonRpcClient.Models
 {
     public class OdooConfig
     {
@@ -7,17 +9,19 @@
         public string DbName { get; }
         public string UserName { get; }
         public string Password { get; }
+        public TimeSpan Timeout { get; }
 
         public OdooContext Context { get; }
 
 
-        public OdooConfig(string apiUrl, string dbName, string userName, string password)
+        public OdooConfig(string apiUrl, string dbName, string userName, string password, TimeSpan timeout = default(TimeSpan))
         {
             this.ApiUrl = apiUrl.TrimEnd(new[] { '/' });
             this.DbName = dbName;
             this.UserName = userName;
             this.Password = password;
             this.Context = new OdooContext();
+            this.Timeout = timeout;
         }
 
         public OdooConfig(string apiUrl, string dbName, string userName, string password, OdooContext context) : this(apiUrl, dbName, userName, password)

--- a/PortaCapena.OdooJsonRpcClient/OdooClient.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooClient.cs
@@ -91,6 +91,7 @@ namespace PortaCapena.OdooJsonRpcClient
         public OdooClient(OdooConfig config)
         {
             Config = config;
+            _client.Timeout = config.Timeout;
         }
 
         #region Get

--- a/PortaCapena.OdooJsonRpcClient/OdooClient.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooClient.cs
@@ -91,7 +91,8 @@ namespace PortaCapena.OdooJsonRpcClient
         public OdooClient(OdooConfig config)
         {
             Config = config;
-            _client.Timeout = config.Timeout;
+            if (config.Timeout != default(TimeSpan))
+                _client.Timeout = config.Timeout;
         }
 
         #region Get


### PR DESCRIPTION
Note that this is not currently working properly if you have multiple OdooClient instances with different timeout. This is because OdooClient share a single static instance of HttpClient.

I disagree with the fact that OdooClient have a Singleton of HttpClient but didn't want to confuse everyone with a complicated merge request.