### PR TITLE
Added support for batch create records

### DIFF
--- a/PortaCapena.OdooJsonRpcClient/Converters/OdooModelMapper.cs
+++ b/PortaCapena.OdooJsonRpcClient/Converters/OdooModelMapper.cs
@@ -214,6 +214,11 @@ namespace PortaCapena.OdooJsonRpcClient.Converters
                 case OdooValueTypeEnum.Reference:
                     return ConvertOdooNameToDotNet(property.Value.RelationField) + OdooModelSuffix;
 
+                case OdooValueTypeEnum.Properties:
+                    return "string";
+                case OdooValueTypeEnum.PropertiesDefinition:
+                    return "string";
+
                 default:
                     throw new ArgumentException($"Not expected Property Value Type: '{property.Value.PropertyValueType}'");
             }

--- a/PortaCapena.OdooJsonRpcClient/Models/OdooPropertyInfo.cs
+++ b/PortaCapena.OdooJsonRpcClient/Models/OdooPropertyInfo.cs
@@ -119,7 +119,10 @@ namespace PortaCapena.OdooJsonRpcClient.Models
                     return OdooValueTypeEnum.One2One;
                 case "monetary":
                     return OdooValueTypeEnum.Monetary;
-
+                case "properties":
+                    return OdooValueTypeEnum.Properties;
+                case "properties_definition":
+                    return OdooValueTypeEnum.PropertiesDefinition;
             }
             throw new Exception($"Cannot unmarshal Enum '{nameof(OdooValueTypeEnum)}' - '{value}'");
         }
@@ -147,6 +150,8 @@ namespace PortaCapena.OdooJsonRpcClient.Models
 
         Selection,
         Text,
-        Html
+        Html,
+        PropertiesDefinition,
+        Properties
     };
 }

--- a/PortaCapena.OdooJsonRpcClient/OdooClient.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooClient.cs
@@ -201,6 +201,17 @@ namespace PortaCapena.OdooJsonRpcClient
             var result = await CallAndDeserializeAsync<object>(request, cancellationToken);
             return result.Succeed ? result.ToResult(result.Value) : OdooResult<object>.FailedResult(result);
         }
+        public async Task<OdooResult<object>> ActionCollectionAsync(string tableName, string action, object param, OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            return await ExecuteWitrAccesDenideRetryAsync(userUid => ActionCollectionAsync(Config, userUid, tableName, action, param, SelectContext(context, Config.Context), cancellationToken));
+        }
+        public static async Task<OdooResult<object>> ActionCollectionAsync(OdooConfig odooConfig, int userUid, string tableName, string action, object model
+            , OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            var request = OdooRequestModel.ActionCollection(odooConfig, userUid, tableName, action, model, context);
+            var result = await CallAndDeserializeAsync<object>(request, cancellationToken);
+            return result.Succeed ? result.ToResult(result.Value) : OdooResult<object>.FailedResult(result);
+        }
 
 
 

--- a/PortaCapena.OdooJsonRpcClient/OdooClient.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooClient.cs
@@ -170,6 +170,29 @@ namespace PortaCapena.OdooJsonRpcClient
             return result.Succeed ? result.ToResult(result.Value) : OdooResult<long>.FailedResult(result);
         }
 
+        public async Task<OdooResult<long[]>> CreateAsync(IEnumerable<IOdooCreateModel> models, OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            return await ExecuteWitrAccesDenideRetryAsync(userUid => CreateAsync(Config, userUid, models, SelectContext(context, Config.Context), cancellationToken));
+        }
+        public static async Task<OdooResult<long[]>> CreateAsync(OdooConfig odooConfig, int userUid, IEnumerable<IOdooCreateModel> models, OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            var request = OdooRequestModel.Create(odooConfig, userUid, models.First().OdooTableName(), models, context);
+            var result = await CallAndDeserializeAsync<long[]>(request, cancellationToken);
+            return result.Succeed ? result.ToResult(result.Value) : OdooResult<long[]>.FailedResult(result);
+        }
+        public async Task<OdooResult<long[]>> CreateAsync(IEnumerable<OdooDictionaryModel> models, OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            return await ExecuteWitrAccesDenideRetryAsync(userUid => CreateAsync(Config, userUid, models, SelectContext(context, Config.Context), cancellationToken));
+        }
+        public static async Task<OdooResult<long[]>> CreateAsync(OdooConfig odooConfig, int userUid, IEnumerable<OdooDictionaryModel> models, OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            var request = OdooRequestModel.Create(odooConfig, userUid, GetTableName(models.First()), models, context);
+            var result = await CallAndDeserializeAsync<long[]>(request, cancellationToken);
+            return result.Succeed ? result.ToResult(result.Value) : OdooResult<long[]>.FailedResult(result);
+        }
+
+
+
         #endregion
 
         #region  Update

--- a/PortaCapena.OdooJsonRpcClient/OdooClient.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooClient.cs
@@ -48,6 +48,7 @@ namespace PortaCapena.OdooJsonRpcClient
 
         static OdooClient()
         {
+            System.Net.ServicePointManager.Expect100Continue = false;
             InitializeHttpClient();
         }
 

--- a/PortaCapena.OdooJsonRpcClient/OdooClient.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooClient.cs
@@ -190,6 +190,17 @@ namespace PortaCapena.OdooJsonRpcClient
             var result = await CallAndDeserializeAsync<long[]>(request, cancellationToken);
             return result.Succeed ? result.ToResult(result.Value) : OdooResult<long[]>.FailedResult(result);
         }
+        public async Task<OdooResult<object>> ActionAsync(string tableName, string action, object param, OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            return await ExecuteWitrAccesDenideRetryAsync(userUid => ActionAsync(Config, userUid, tableName, action, param, SelectContext(context, Config.Context), cancellationToken));
+        }
+        public static async Task<OdooResult<object>> ActionAsync(OdooConfig odooConfig, int userUid, string tableName, string action, object model
+            , OdooContext context = null, CancellationToken cancellationToken = default)
+        {
+            var request = OdooRequestModel.Action(odooConfig, userUid, tableName, action, model, context);
+            var result = await CallAndDeserializeAsync<object>(request, cancellationToken);
+            return result.Succeed ? result.ToResult(result.Value) : OdooResult<object>.FailedResult(result);
+        }
 
 
 

--- a/PortaCapena.OdooJsonRpcClient/OdooRepository.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooRepository.cs
@@ -68,5 +68,9 @@ namespace PortaCapena.OdooJsonRpcClient
         {
             return await OdooClient.DeleteRangeAsync(models as IOdooModel[], context);
         }
+        public async Task<OdooResult<object>> ActionAsync(string action, object args, OdooContext context = null)
+        {
+            return await OdooClient.ActionAsync(TableName, action, args, context);
+        }
     }
 }

--- a/PortaCapena.OdooJsonRpcClient/OdooRepository.cs
+++ b/PortaCapena.OdooJsonRpcClient/OdooRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using PortaCapena.OdooJsonRpcClient.Extensions;
 using PortaCapena.OdooJsonRpcClient.Models;
 using PortaCapena.OdooJsonRpcClient.Request;
@@ -27,6 +28,14 @@ namespace PortaCapena.OdooJsonRpcClient
         public async Task<OdooResult<long>> CreateAsync(OdooDictionaryModel model, OdooContext context = null)
         {
             return await OdooClient.CreateAsync(model, context);
+        }
+        public async Task<OdooResult<long[]>> CreateAsync(IEnumerable<IOdooCreateModel> models, OdooContext context = null)
+        {
+            return await OdooClient.CreateAsync(models, context);
+        }
+        public async Task<OdooResult<long[]>> CreateAsync(IEnumerable<OdooDictionaryModel> models, OdooContext context = null)
+        {
+            return await OdooClient.CreateAsync(models, context);
         }
 
         public async Task<OdooResult<bool>> UpdateAsync(IOdooCreateModel model, long id, OdooContext context = null)

--- a/PortaCapena.OdooJsonRpcClient/Request/OdooRequestModel.cs
+++ b/PortaCapena.OdooJsonRpcClient/Request/OdooRequestModel.cs
@@ -95,6 +95,11 @@ namespace PortaCapena.OdooJsonRpcClient.Request
             var param = new OdooRequestParams(config.ApiUrlJson, "object", "execute_kw", config.DbName, uid, config.Password, tableName, OdooOperation.GetMetadata, new object[] { ids }, MapQuery(context));
             return new OdooRequestModel(param);
         }
+        public static OdooRequestModel Action(OdooConfig config, int uid, string tableName, string action, object model, OdooContext context = null)
+        {
+            var param = new OdooRequestParams(config.ApiUrlJson, "object", "execute_kw", config.DbName, uid, config.Password, tableName, action, new[] { model }, MapQuery(context));
+            return new OdooRequestModel(param);
+        }
 
         protected static Dictionary<string, object> MapQuery(OdooContext context, OdooQuery query = null)
         {

--- a/PortaCapena.OdooJsonRpcClient/Request/OdooRequestModel.cs
+++ b/PortaCapena.OdooJsonRpcClient/Request/OdooRequestModel.cs
@@ -100,6 +100,11 @@ namespace PortaCapena.OdooJsonRpcClient.Request
             var param = new OdooRequestParams(config.ApiUrlJson, "object", "execute_kw", config.DbName, uid, config.Password, tableName, action, new[] { model }, MapQuery(context));
             return new OdooRequestModel(param);
         }
+        public static OdooRequestModel ActionCollection(OdooConfig config, int uid, string tableName, string action, object model, OdooContext context = null)
+        {
+            var param = new OdooRequestParams(config.ApiUrlJson, "object", "execute_kw", config.DbName, uid, config.Password, tableName, action, model, MapQuery(context));
+            return new OdooRequestModel(param);
+        }
 
         protected static Dictionary<string, object> MapQuery(OdooContext context, OdooQuery query = null)
         {

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ var result = await repository.UpdateAsync(model, productId);
 var deleteProductResult = await repository.DeleteAsync(productId);
 ```
 
+#### Action
+Perform any actions on a model. For example use the code below to comfirm a sale order and turn it from a quote to an order.
+```C#    
+var repository = new OdooRepository<SaleOrderOdooModel>(config);                    
+var confirmResult = await repository.ActionAsync("action_confirm", orderId);
+```
 
 
 


### PR DESCRIPTION
To speed up imports and to avoid issues with rate limiting it is necessary to create records in batches using a single API call.